### PR TITLE
call es6-promise's `polyfill` method so `Promise` isn't overwritten

### DIFF
--- a/neat-audio.js
+++ b/neat-audio.js
@@ -1,4 +1,4 @@
-var Promise = require('es6-promise').Promise;
+require('es6-promise').polyfill();
 
 function requestSound(url) {
   return new Promise(


### PR DESCRIPTION
fixes a JSHint error about a `Redefinition of Promise`